### PR TITLE
Fix collections.abc import for Python 3.10

### DIFF
--- a/src/python/compreffor/test/dummy.py
+++ b/src/python/compreffor/test/dummy.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+import collections.abc
 
-class DummyGlyphSet(collections.MutableMapping):
+
+class DummyGlyphSet(collections.abc.MutableMapping):
     """Behaves like a glyphset for testing purposes"""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Since Python 3.3, `MutableMapping` has been available in `collections.abc`.

Since Python 3.9, `MutableMapping` is only available in `collections.abc`.


```pycon
Python 3.9.0a2+ (heads/master:ec007cb, Jan  5 2020, 12:34:22)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import collections
>>> collections.MutableMapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'collections' has no attribute 'MutableMapping'
>>> collections.abc.MutableMapping
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'collections' has no attribute 'abc'
>>> import collections.abc
>>> collections.abc.MutableMapping
<class 'collections.abc.MutableMapping'>
>>>
```

Python 3.9 is in alpha with full release due in October.

Fedora are already making early builds for 3.9 and found this problem: https://bugzilla.redhat.com/show_bug.cgi?id=1792029.
