### PR TITLE
Temporarily pin cython<3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "setuptools_scm",
     "setuptools_git_ls_files",
-    "cython",
+    "cython<3",
 ]
 
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Works around, but does not fix, https://github.com/googlefonts/compreffor/issues/150.