### PR TITLE
Use old_build_ext for Cython 3 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "wheel",
     "setuptools_scm",
     "setuptools_git_ls_files",
-    "cython<3",
+    "cython",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ except pkg_resources.ResolutionError:
 else:
     with_cython = True
     print('Development mode: Compiling Cython modules from .pyx sources.')
-    from Cython.Distutils import build_ext
+    from Cython.Distutils.old_build_ext import old_build_ext as build_ext
 
 
 class custom_build_ext(build_ext):


### PR DESCRIPTION
Replace `Cython.Distutils.build_ext` with `Cython.Distutils.old_build_ext.old_build_ext`.

This appears to make `compreffor` compatible with Cython 3 while preserving compatibility with (at least recent versions of?) Python 2.

I’m sure it would be possible to fix this in a much nicer way by adapting to the current `build_ext` API, but I’m not planning to work on that at the moment.

Fixes https://github.com/googlefonts/compreffor/issues/150.