### PR TITLE
Only depend on setuptools-git-ls-files for sdist

### DIFF
--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,19 @@
+"""
+This is a custom PEP 517 build backend that extends setuptool's build backend
+in order to provide different dependencies for wheel and sdist builds.
+
+Please see the following link for documentation about this technique:
+
+https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+"""
+
+from setuptools import build_meta as _orig
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return _orig.get_requires_for_build_sdist(config_settings) + [
+        # Finds all git tracked files including submodules, when
+        # making sdist MANIFEST
+        "setuptools-git-ls-files"
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,8 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel",
     "setuptools_scm",
-    "setuptools_git_ls_files",
     "cython",
 ]
-
-build-backend = "setuptools.build_meta"
+build-backend = "backend"
+backend-path = ["_custom_build"]

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,6 @@ import sys
 
 needs_pytest = {'pytest', 'test'}.intersection(sys.argv)
 pytest_runner = ['pytest_runner'] if needs_pytest else []
-needs_wheel = {'bdist_wheel'}.intersection(sys.argv)
-wheel = ['wheel'] if needs_wheel else []
 
 
 # use Cython if available, else try use pre-generated .cpp sources
@@ -152,7 +150,7 @@ setup_params = dict(
         'build_ext': custom_build_ext,
     },
     setup_requires=(
-        ["setuptools_scm", "setuptools_git_ls_files"] + pytest_runner + wheel
+        pytest_runner
     ),
     tests_require=[
         'pytest>=2.8',


### PR DESCRIPTION
Some PEP 517 build frontends, like PyPA build, have a feature to check that build dependencies are present prior to starting the build.

The setuptools-git-ls-files dependency is only needed when constructing the sdist but not when building a wheel. Some package managers, such as nixpkgs, only build wheels but still need to bundle and depend on this to pass validation.

This commit adds some complexity to specify that setuptools-git-ls-files is only needed when building an sdist by extending setuptools.

This is the same solution implemented in https://github.com/adobe-type-tools/cffsubr/pull/23.