### PR TITLE
Work on CFF2 instead of CFF

### DIFF
--- a/src/python/compreffor/__init__.py
+++ b/src/python/compreffor/__init__.py
@@ -15,7 +15,7 @@
 
 """
 ==== TTX/FontTools Compreffor ====
-This module automatically subroutines the CFF table in
+This module automatically subroutines the CFF2 table in
 a TTFont object, for the purposes of compressing the
 outputted font file. In addition to providing a Python
 interface, this tool can be used on the command line.
@@ -90,7 +90,7 @@ def compress(ttFont, method_python=False, **options):
 
 
 def decompress(ttFont, **kwargs):
-    """ Use the FontTools Subsetter to desubroutinize the font's CFF table.
+    """ Use the FontTools Subsetter to desubroutinize the font's CFF2 table.
     Any keyword arguments are passed on as options to the Subsetter.
     Skip if the font contains no subroutines.
     """
@@ -102,7 +102,7 @@ def decompress(ttFont, **kwargs):
 
     # The FontTools subsetter modifies many tables by default; here
     # we only want to desubroutinize, so we run the subsetter on a
-    # temporary copy and extract the resulting CFF table from it
+    # temporary copy and extract the resulting CFF2 table from it
     make_temp = kwargs.pop('make_temp', True)
     if make_temp:
         from io import BytesIO
@@ -124,19 +124,19 @@ def decompress(ttFont, **kwargs):
     subsetter.subset(tmpfont)
 
     if make_temp:
-        # copy modified CFF table to original font
-        data = tmpfont['CFF '].compile(tmpfont)
-        table = newTable('CFF ')
+        # copy modified CFF2 table to original font
+        data = tmpfont['CFF2'].compile(tmpfont)
+        table = newTable('CFF2')
         table.decompile(data, ttFont)
-        ttFont['CFF '] = table
+        ttFont['CFF2'] = table
         tmpfont.close()
 
 
 def has_subrs(ttFont):
-    """ Return True if the font's CFF table contains any subroutines. """
-    if 'CFF ' not in ttFont:
-        raise ValueError("Invalid font: no 'CFF ' table found")
-    td = ttFont['CFF '].cff.topDictIndex[0]
+    """ Return True if the font's CFF2 table contains any subroutines. """
+    if 'CFF2' not in ttFont:
+        raise ValueError("Invalid font: no 'CFF2' table found")
+    td = ttFont['CFF2'].cff.topDictIndex[0]
     all_subrs = [td.GlobalSubrs]
     if hasattr(td, 'FDArray'):
         all_subrs.extend(fd.Private.Subrs for fd in td.FDArray

--- a/src/python/compreffor/__main__.py
+++ b/src/python/compreffor/__main__.py
@@ -36,7 +36,7 @@ def parse_arguments(args=None):
                         help="limit to the number of subroutines per INDEX "
                         " (default: 65533)")
     parser.add_argument('--generate-cff', action='store_true',
-                        help="Also save binary CFF table data as {INPUT}.cff")
+                        help="Also save binary CFF2 table data as {INPUT}.cff")
     parser.add_argument('--py', dest="method_python", action='store_true',
                         help="Use pure Python method, instead of C++ extension")
     py_meth_group = parser.add_argument_group("options for pure Python method")
@@ -116,8 +116,8 @@ def main(args=None):
     if generate_cff:
         cff_file = os.path.splitext(outfile)[0] + ".cff"
         with open(cff_file, 'wb') as f:
-            font['CFF '].cff.compile(f, None)
-        log.info("Saved CFF data to '%s'" % os.path.basename(cff_file))
+            font['CFF2'].cff.compile(f, None)
+        log.info("Saved CFF2 data to '%s'" % os.path.basename(cff_file))
 
     if check:
         log.info("Checking compression integrity and call depth")

--- a/src/python/compreffor/cxxCompressor.py
+++ b/src/python/compreffor/cxxCompressor.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Tool to subroutinize a CFF OpenType font. Backed by a C++ binary.
+Tool to subroutinize a CFF2 OpenType font. Backed by a C++ binary.
 
 This file is a bootstrap for the C++ edition of the FontTools compreffor.
 It prepares the input data for the extension and reads back in the results,
@@ -193,9 +193,9 @@ def compreff(font, nrounds=None, max_subrs=None):
     """Main function that compresses `font`, a TTFont object,
     in place.
     """
-    assert len(font['CFF '].cff.topDictIndex) == 1
+    assert len(font['CFF2'].cff.topDictIndex) == 1
 
-    td = font['CFF '].cff.topDictIndex[0]
+    td = font['CFF2'].cff.topDictIndex[0]
 
     if nrounds is None:
         nrounds = Compreffor.NROUNDS

--- a/src/python/compreffor/pyCompressor.py
+++ b/src/python/compreffor/pyCompressor.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Tool to subroutinize a CFF OpenType font.
+Tool to subroutinize a CFF2 OpenType font.
 
 Usage (command line):
 >> ./pyCompressor.py /path/to/font.otf
@@ -431,7 +431,7 @@ class Compreffor(object):
         Initialize the compressor.
 
         Arguments:
-        font -- the TTFont to compress, must be a CFF font
+        font -- the TTFont to compress, must be a CFF2 font
         nrounds -- specifies the number of rounds to run
         max_subrs -- specify the limit on the number of subrs in an INDEX
         chunk_ratio -- sets the POOL_CHUNKRATIO parameter
@@ -441,8 +441,8 @@ class Compreffor(object):
         """
 
         if isinstance(font, TTFont):
-            assert "CFF " in font
-            assert len(font["CFF "].cff.topDictIndex) == 1
+            assert "CFF2" in font
+            assert len(font["CFF2"].cff.topDictIndex) == 1
             self.font = font
         else:
             log.warning("non-TTFont given to Compreffor")
@@ -450,7 +450,7 @@ class Compreffor(object):
 
         if chunk_ratio is not None:
             self.POOL_CHUNKRATIO = chunk_ratio
-        elif font and (len(font["CFF "].cff.topDictIndex[0].charset) <
+        elif font and (len(font["CFF2"].cff.topDictIndex[0].charset) <
                        self.CHUNK_CHARSET_CUTOFF):
             self.POOL_CHUNKRATIO = self.LATIN_POOL_CHUNKRATIO
         if nrounds is not None:
@@ -472,7 +472,7 @@ class Compreffor(object):
     def compress(self):
         """Compress the provided font using the iterative method"""
 
-        top_dict = self.font["CFF "].cff.topDictIndex[0]
+        top_dict = self.font["CFF2"].cff.topDictIndex[0]
 
         multi_font = hasattr(top_dict, "FDArray")
 

--- a/src/python/compreffor/test/util.py
+++ b/src/python/compreffor/test/util.py
@@ -59,7 +59,7 @@ def check_call_depth(compressed_file):
 
     f = ttLib.TTFont(compressed_file)
 
-    return check_cff_call_depth(f["CFF "].cff)
+    return check_cff_call_depth(f["CFF2"].cff)
 
 
 def check_cff_call_depth(cff):


### PR DESCRIPTION
A crude hack to support CFF2 only.

https://github.com/googlefonts/compreffor/issues/157

Leaving it here for now.